### PR TITLE
bunch more fixes

### DIFF
--- a/diagram_parser/parser/diagram_parser.py
+++ b/diagram_parser/parser/diagram_parser.py
@@ -42,7 +42,7 @@ def multithread_solve(parameters):
         legal = True
         import re
         #print (re.split(',\(\)', result))
-        for element in re.split('[,\(\)]', result):
+        for element in re.split(r'[,\(\)]', result):
             try:
                 val = int(element.replace('point_', ''))
                 if val in delete_points:

--- a/diagram_parser/parser/load_symbol.py
+++ b/diagram_parser/parser/load_symbol.py
@@ -64,8 +64,11 @@ def load_symbol(problem_list, ocr_path, box_path):
                 with open(os.path.join(current_path, tex_id + ".txt"), "r") as f:
                     position = tuple(map(int, f.readline().split(',')[:-1]))
                 #print (position, os.path.join(current_path, tex_id + ".json"))
-                with open(os.path.join(current_path, tex_id + ".json"), "r") as f:
-                    mathpix = json.load(f)
+                try:
+                    with open(os.path.join(current_path, tex_id + ".json"), "r") as f:
+                        mathpix = json.load(f)
+                except FileNotFoundError:
+                    raise Exception("Can not find the mathpix result:", os.path.join(current_path, tex_id + ".json"))
                 
                 label = ""
                 if 'data' in mathpix and type(mathpix['data']) in [list, tuple] and len(mathpix['data']) > 0:

--- a/diagram_parser/parser/parse_symbol.py
+++ b/diagram_parser/parser/parse_symbol.py
@@ -62,7 +62,7 @@ def generate_label(graph_parse, ocr_result, delete_points, factor, log_message):
         
         if "^{\circ}" in label:
             structure['type'] = 'angle angle'
-            structure['label'] = label[0: label.find("^{\circ}")]
+            structure['label'] = label[0: label.find(r"^{\circ}")]
         elif len(label) == 1 and label.isalpha():
             alpha = 1
             if len(line_distances) > 0 and len(point_distances) > 0:

--- a/symbolic_solver/logic_parser.py
+++ b/symbolic_solver/logic_parser.py
@@ -1,3 +1,5 @@
+from contextlib import redirect_stdout
+import io
 from pyparsing import Optional, alphanums, Forward, Group, Word, Literal, ZeroOrMore
 
 from extended_definition import ExtendedDefinition
@@ -15,7 +17,7 @@ class LogicParser:
         self.logic = logic
         self.expression = Forward()
 
-        identifier = Word(alphanums + ' +-*/.\\\{\}^_$\'')
+        identifier = Word(alphanums + r' +-*/.\\\{\}^_$\'')
         # integer  = Word( nums )
         lparen = Literal("(").suppress()  # suppress "(" in the result
         rparen = Literal(")").suppress()  # suppress ")" in the result
@@ -46,11 +48,9 @@ class LogicParser:
                 if expr.find("angle") != -1:  # 'angle_1'
                     return Symbol(expr)
                 try:
-                    import sys
-                    savedStdout = sys.stdout
-                    sys.stdout = None  # close the stdout to mute the warning information
-                    val = parse_latex(expr).evalf()  # evaluate the latex expression to a numerical value
-                    sys.stdout = savedStdout  # open the stdout
+                    with io.StringIO() as buf, redirect_stdout(buf):
+                        val = parse_latex(expr).evalf()  # evaluate the latex expression to a numerical value
+
                     return val
                 except:
                     return self.EvaluateSymbols(expr)  # special case: convert the expression to a symbol

--- a/symbolic_solver/logic_solver.py
+++ b/symbolic_solver/logic_solver.py
@@ -651,7 +651,7 @@ class LogicSolver:
 
         if target is None:
             return None
-        assert (self.can_search, "Please execute initSearch() before search.")
+        assert self.can_search, "Please execute initSearch() before search."
 
         # try to get the answer before using theorems
         step_lst = []

--- a/theorem_predict/eval_transformer.py
+++ b/theorem_predict/eval_transformer.py
@@ -45,7 +45,7 @@ def evaluate(diagram_logic_file, text_logic_file, tokenizer_name, model_name, ch
         seq = []
         for j in range(seq_num):
             res = tokenizer.decode(output[j].tolist())
-            res = res.replace("</s>", "").replace("<s>", "").replace("<pad>", "")
+            res = '['+res.replace("</s>", "").replace("<s>", "").replace("<pad>", "")
             # print(res)
             try:
                 res = ast.literal_eval(res) # string class to list class


### PR DESCRIPTION
diagram_parser/parser/diagram_parser.py - fixed incorrectly escaped string

diagram_parser/parser/load_symbol.py - better error message

diagram_parser/parser/parse_symbol.py - fixed incorrectly escaped string

symbolic_solver/logic_parser.py - this stdout logic broke python's ability to print. probably worked in older versions of python, but for whatever reason it broke printing on my python machine. using these context managers is the "correct" way to temporarily silence stdout.

symbolic_solver/logic_solver.py - those brackets mean you are asserting a tuple, not passing arguments.

theorem_predict/eval_transformer.py - not sure why but at some point the decoder logic changed and it stopped including '[' in it. Feel free to try it on your machine, but nowadays we need to manually add the '['. idk why.

theorem_predict/train_transformer.py - previously didnt work on my 8gb vram gpu but does now. mainly optimisation is just dereferencing the train tensors once we're done with them.

